### PR TITLE
Added missing schematics and gild improvement

### DIFF
--- a/src/main/resources/data/tetra/improvements/polearm/shared/hone_gild.json
+++ b/src/main/resources/data/tetra/improvements/polearm/shared/hone_gild.json
@@ -1,0 +1,46 @@
+[
+    {
+        "key": "hone_gild",
+        "level": 1,
+        "aspects": {
+            "honed": 1
+        },
+        "magicCapacity": 12
+    },
+    {
+        "key": "hone_gild",
+        "level": 2,
+        "integrity": -1,
+        "aspects": {
+            "honed": 2
+        },
+        "magicCapacity": 24
+    },
+    {
+        "key": "hone_gild",
+        "level": 3,
+        "integrity": -1,
+        "aspects": {
+            "honed": 3
+        },
+        "magicCapacity": 36
+    },
+    {
+        "key": "hone_gild",
+        "level": 4,
+        "integrity": -2,
+        "aspects": {
+            "honed": 4
+        },
+        "magicCapacity": 48
+    },
+    {
+        "key": "hone_gild",
+        "level": 5,
+        "integrity": -2,
+        "aspects": {
+            "honed": 5
+        },
+        "magicCapacity": 60
+    }
+]

--- a/src/main/resources/data/tetra/schematics/polearm/shared/hone_gild_1.json
+++ b/src/main/resources/data/tetra/schematics/polearm/shared/hone_gild_1.json
@@ -1,0 +1,51 @@
+{
+    "replace": false,
+    "localizationKey": "shared/hone_gild_1",
+    "slots": [
+        "polearm/handle",
+        "polearm/head"
+    ],
+    "keySuffixes": [
+        "_polearm_handle",
+        "_polearm_head"
+    ],
+    "hone": true,
+    "rarity": "hone",
+    "displayType": "major",
+    "glyph": {
+        "textureX": 112,
+        "textureY": 240
+    },
+    "materialSlotCount": 1,
+    "requirement": {
+        "type": "tetra:and",
+        "requirements": [
+            {
+                "type": "tetra:locked",
+                "key": "tetra:hone/gild_1"
+            },
+            {
+                "type": "tetra:not",
+                "requirement": {
+                    "type": "tetra:improvement",
+                    "improvement": "hone_gild"
+                }
+            }
+        ]
+    },
+    "outcomes": [
+        {
+            "material": {
+                "items": [ "minecraft:gold_nugget" ],
+                "count": 3
+            },
+            "requiredTools": {
+                "hammer_dig": "minecraft:stone"
+            },
+            "experienceCost": 3,
+            "improvements": {
+                "hone_gild": 1
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/tetra/schematics/polearm/shared/hone_gild_2.json
+++ b/src/main/resources/data/tetra/schematics/polearm/shared/hone_gild_2.json
@@ -1,0 +1,49 @@
+{
+    "replace": false,
+    "localizationKey": "shared/hone_gild_2",
+    "slots": [
+        "polearm/handle",
+        "polearm/head"
+    ],
+    "keySuffixes": [
+        "_polearm_handle",
+        "_polearm_head"
+    ],
+    "hone": true,
+    "rarity": "hone",
+    "displayType": "major",
+    "glyph": {
+        "textureX": 112,
+        "textureY": 240
+    },
+    "materialSlotCount": 1,
+    "requirement": {
+        "type": "tetra:and",
+        "requirements": [
+            {
+                "type": "tetra:locked",
+                "key": "tetra:hone/gild_2"
+            },
+            {
+                "type": "tetra:improvement",
+                "improvement": "hone_gild",
+                "level": 1
+            }
+        ]
+    },
+    "outcomes": [
+        {
+            "material": {
+                "items": [ "minecraft:gold_nugget" ],
+                "count": 4
+            },
+            "requiredTools": {
+                "hammer_dig": "minecraft:stone"
+            },
+            "experienceCost": 4,
+            "improvements": {
+                "hone_gild": 2
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/tetra/schematics/polearm/shared/hone_gild_3.json
+++ b/src/main/resources/data/tetra/schematics/polearm/shared/hone_gild_3.json
@@ -1,0 +1,49 @@
+{
+    "replace": false,
+    "localizationKey": "shared/hone_gild_3",
+    "slots": [
+        "polearm/handle",
+        "polearm/head"
+    ],
+    "keySuffixes": [
+        "_polearm_handle",
+        "_polearm_head"
+    ],
+    "hone": true,
+    "rarity": "hone",
+    "displayType": "major",
+    "glyph": {
+        "textureX": 112,
+        "textureY": 240
+    },
+    "materialSlotCount": 1,
+    "requirement": {
+        "type": "tetra:and",
+        "requirements": [
+            {
+                "type": "tetra:locked",
+                "key": "tetra:hone/gild_3"
+            },
+            {
+                "type": "tetra:improvement",
+                "improvement": "hone_gild",
+                "level": 2
+            }
+        ]
+    },
+    "outcomes": [
+        {
+            "material": {
+                "items": [ "minecraft:gold_nugget" ],
+                "count": 5
+            },
+            "requiredTools": {
+                "hammer_dig": "minecraft:stone"
+            },
+            "experienceCost": 5,
+            "improvements": {
+                "hone_gild": 3
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/tetra/schematics/polearm/shared/hone_gild_4.json
+++ b/src/main/resources/data/tetra/schematics/polearm/shared/hone_gild_4.json
@@ -1,0 +1,49 @@
+{
+    "replace": false,
+    "localizationKey": "shared/hone_gild_4",
+    "slots": [
+        "polearm/handle",
+        "polearm/head"
+    ],
+    "keySuffixes": [
+        "_polearm_handle",
+        "_polearm_head"
+    ],
+    "hone": true,
+    "rarity": "hone",
+    "displayType": "major",
+    "glyph": {
+        "textureX": 112,
+        "textureY": 240
+    },
+    "materialSlotCount": 1,
+    "requirement": {
+        "type": "tetra:and",
+        "requirements": [
+            {
+                "type": "tetra:locked",
+                "key": "tetra:hone/gild_4"
+            },
+            {
+                "type": "tetra:improvement",
+                "improvement": "hone_gild",
+                "level": 3
+            }
+        ]
+    },
+    "outcomes": [
+        {
+            "material": {
+                "items": [ "minecraft:gold_nugget" ],
+                "count": 6
+            },
+            "requiredTools": {
+                "hammer_dig": "minecraft:stone"
+            },
+            "experienceCost": 6,
+            "improvements": {
+                "hone_gild": 4
+            }
+        }
+    ]
+}

--- a/src/main/resources/data/tetra/schematics/polearm/shared/hone_gild_5.json
+++ b/src/main/resources/data/tetra/schematics/polearm/shared/hone_gild_5.json
@@ -1,0 +1,49 @@
+{
+    "replace": false,
+    "localizationKey": "shared/hone_gild_5",
+    "slots": [
+        "polearm/handle",
+        "polearm/head"
+    ],
+    "keySuffixes": [
+        "_polearm_handle",
+        "_polearm_head"
+    ],
+    "hone": true,
+    "rarity": "hone",
+    "displayType": "major",
+    "glyph": {
+        "textureX": 112,
+        "textureY": 240
+    },
+    "materialSlotCount": 1,
+    "requirement": {
+        "type": "tetra:and",
+        "requirements": [
+            {
+                "type": "tetra:locked",
+                "key": "tetra:hone/gild_5"
+            },
+            {
+                "type": "tetra:improvement",
+                "improvement": "hone_gild",
+                "level": 4
+            }
+        ]
+    },
+    "outcomes": [
+        {
+            "material": {
+                "items": [ "minecraft:gold_nugget" ],
+                "count": 7
+            },
+            "requiredTools": {
+                "hammer_dig": "minecraft:stone"
+            },
+            "experienceCost": 7,
+            "improvements": {
+                "hone_gild": 5
+            }
+        }
+    ]
+}


### PR DESCRIPTION
After analyzing the code from both tetra and sofr, the files that control gilding have been identified and added.
The fix is purely data driven and can be applied trough a datapack.
This PR includes the missing files required for gilding the polearm parts.
![image](https://github.com/AceTheEldritchKing/Secrets-Of-Forging-Revelations/assets/69213368/0f37409c-fa55-48a5-9be5-7abcb2050840)
As it can be seen in the picture the polearms can now be gilded.